### PR TITLE
fix: Migrating Gauge data [DHIS2-7886]

### DIFF
--- a/coordination/flyway_versioning.md
+++ b/coordination/flyway_versioning.md
@@ -36,7 +36,7 @@ The table below contains a list of migration versions. Please reserve the approp
 | V2_34_6 | |
 | V2_34_7 | https://github.com/dhis2/dhis2-core/pull/4478 |
 | V2_34_8 | https://github.com/dhis2/dhis2-core/pull/4411 |
-| V2_34_ | |
+| V2_34_9 | https://github.com/dhis2/dhis2-core/pull/4587 |
 | V2_34_ | |
 | V2_34_ | |
 | V2_34_ | |


### PR DESCRIPTION
Reserving a version for the issue DHIS2-7886. Relates to Gauge charts data migration.