### PR TITLE
feat: Reserving version V2_35_11 for high-priority item [DHIS2-9124]

### DIFF
--- a/coordination/flyway_versioning.md
+++ b/coordination/flyway_versioning.md
@@ -68,7 +68,7 @@ The table below contains a list of migration versions. Please reserve the approp
 | V2_35_8 | https://github.com/dhis2/dhis2-core/pull/5779 |
 | V2_35_9 | https://github.com/dhis2/dhis2-core/pull/5784 |
 | V2_35_10 | https://github.com/dhis2/dhis2-core/pull/5644 |
-| V2_35_11 | https://github.com/dhis2/dhis2-core/pull/5830 |
+| V2_35_11 | https://github.com/dhis2/dhis2-core/pull/5876 |
 | V2_35_ | |
 | V2_35_ | |
 | V2_35_ | |


### PR DESCRIPTION
I had to take the version from the PR https://github.com/dhis2/dhis2-core/pull/5830. This PR should be updated to version Flyways script 12 now [DHIS2-9124]