### PR TITLE
feat(skills): add syncing-dhis2-translations Claude Code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The purpose of this document is to works as a resource for any developer working
 1. Using this document
 2. Contributing
 3. Guides
-3. Coordination
+4. Coordination
+5. Skills (for Claude Code)
 
 ## Using this document
 
@@ -68,6 +69,12 @@ The following pages contain high-level developer documentation for various solut
 * [Job scheduling](docs/job_scheduling.md)
 * [Data value set import/export](docs/datavalueset.md)
 * [Auditing](guides/auditing.md)
+
+## Skills (for Claude Code)
+
+Reusable Claude Code skills that capture team workflows. See [`skills/`](skills/) for the list and installation instructions.
+
+* [`syncing-dhis2-translations`](skills/syncing-dhis2-translations/) — fixing fake "English-as-translation" entries, pushing to Transifex, handling stuck `dhis2-bot` sync PRs, coordinating cleanup across release branches.
 
 ## Talks
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,71 @@
+# Skills
+
+[Claude Code skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) that capture DHIS2 backend workflows. A skill is a small directory containing a `SKILL.md` (with YAML frontmatter describing when to invoke it) and any supporting scripts or reference files. When a developer is working with Claude Code in any DHIS2 repo, an installed skill is auto-discovered and invoked when the description matches their task.
+
+This directory exists so that team-wide workflows can live in one place and benefit everyone, rather than each developer reinventing them.
+
+## Available skills
+
+| Skill | When it applies |
+|---|---|
+| [`syncing-dhis2-translations`](./syncing-dhis2-translations/) | Fixing fake "English-as-translation" entries in `i18n_global_*.properties`, pushing translation cleanup to Transifex via `tx`, handling stuck `dhis2-bot` sync PRs, and coordinating cleanup across master + supported branches |
+
+## Installing a skill locally
+
+Pick one approach:
+
+### Option A — symlink (recommended; gets updates via `git pull`)
+
+```bash
+# Assumes wow-backend is cloned at ~/src/dhis2/wow-backend (adjust as needed)
+mkdir -p ~/.claude/skills
+ln -s ~/src/dhis2/wow-backend/skills/syncing-dhis2-translations \
+      ~/.claude/skills/syncing-dhis2-translations
+```
+
+Run `ls -la ~/.claude/skills/` to confirm. Next time you start Claude Code, the skill description appears in the available-skills list and Claude will invoke it when your task matches the description.
+
+### Option B — copy (frozen at copy time)
+
+```bash
+cp -r ~/src/dhis2/wow-backend/skills/syncing-dhis2-translations \
+      ~/.claude/skills/
+```
+
+### Verifying installation
+
+Inside Claude Code, ask something like *"do we have a skill for fixing DHIS2 translations?"* — Claude should reference `syncing-dhis2-translations` from the available list.
+
+## Contributing a new skill
+
+1. Branch off `master`: `git checkout -b feat/skill-<name>`
+2. Create `skills/<your-skill-name>/SKILL.md` with the YAML frontmatter:
+   ```yaml
+   ---
+   name: <gerund-form-name>
+   description: Use when <specific triggering conditions and symptoms>
+   ---
+   ```
+3. Keep `SKILL.md` under ~500 lines. Use [Anthropic's skill-authoring guide](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices) for structure.
+4. Put reusable scripts as separate files in the same directory (not inlined in `SKILL.md`).
+5. Update the table above and open a PR.
+
+### Naming conventions
+
+- Use **gerund form** (verb + -ing): `syncing-dhis2-translations`, `migrating-postgres-schemas`, `debugging-tracker-imports`
+- Hyphenated, lowercase, no spaces
+- Specific enough that the description triggers cleanly without overlapping other skills
+
+### Description field
+
+The `description` is the single most important line for skill discovery. Start with **"Use when ..."** and list concrete triggers, not the workflow:
+
+```yaml
+# ✅ Good
+description: Use when investigating Flyway migration conflicts during a backport — out-of-order versions across release branches, coordination doc out of sync, failed startup with "Detected resolved migration not applied to database".
+
+# ❌ Bad — describes the workflow instead of the trigger
+description: Walks through three steps to resolve Flyway conflicts.
+```
+
+See the [Claude Code skill best practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices) for more detail.

--- a/skills/syncing-dhis2-translations/SKILL.md
+++ b/skills/syncing-dhis2-translations/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: syncing-dhis2-translations
+description: Use when fixing DHIS2 core translations — English text showing in non-English UI, fake "English-as-translation" entries in i18n_global_*.properties, blocked dhis2-bot translation-sync PRs, coordinating cleanup across master + supported branches, or pushing translations to the hisp-uio Transifex project via tx CLI. Covers the dhis2/transifex-ci pipeline.
+---
+
+# Syncing DHIS2 Translations
+
+## What this is
+
+DHIS2 uses **Transifex** for translations (project `o:hisp-uio:p:app-server-side-resources`). The sync between Transifex and `dhis2/dhis2-core` is automated by `dhis2/transifex-ci`. This skill covers the four common tasks: detecting and cleaning fake "English-as-translation" entries, pushing fixes back to Transifex, unblocking the auto-sync PRs, and backporting cleanup to supported release branches.
+
+## The official pipeline (from Phil, the translation owner)
+
+```
+1. Change source string → PR to dhis2-core → merge
+2. Nightly dhis2/transifex-ci cron pushes new source strings to Transifex
+3. Translators (humans, or AI via `tx push -t` CLI) provide translations in Transifex
+4. Next nightly cron pulls translations and opens/updates a sync PR per branch in dhis2-core
+5. Merge the sync PR when ready
+```
+
+Repo: https://github.com/dhis2/transifex-ci · Daily cron 23:11 UTC · Weekly Saturdays 22:41 UTC · Both support `workflow_dispatch` for manual triggering from the Actions UI.
+
+## The "fake translation" pattern
+
+The recurring bug: an entry in `i18n_global_<lang>.properties` has the same value as the English source. Examples:
+
+```
+# i18n_global_ru.properties
+verify_email_subject=Verify email address        # ← English, not Russian
+F_IMPERSONATE_USER=Impersonate user              # ← English
+```
+
+This happens when someone (or some sync) wrote the English source as a "translation". Transifex marks it translated, so it doesn't appear in translator queues, but users see English in the non-English UI.
+
+**Detection:** byte-equal comparison between target value and English source. Run `audit-fake-translations.py` (this skill dir) to list them per language.
+
+**False positives to skip:**
+- Brand names that don't translate: `openid=OpenID`
+- Common short words that legitimately match: `two_factor_code=Code` (in `fr`/`nl`/`da` "Code" is the real translation; in non-Latin-script langs it's English left as-is — needs human judgment)
+
+## The cleanup workflow
+
+For one or more keys / a domain (e.g. all security-related strings):
+
+1. **Audit per language** — run `audit-fake-translations.py --keys <key1,key2,…>` (or with a regex) to confirm scope.
+2. **Delete fakes in repo** — run `delete-fake-translations.py` with the same keys. Script ONLY deletes lines where target value byte-equals English source. Real translations preserved. Never use a blind `sed -i` that doesn't check the value.
+3. **Push to Transifex** — `~/.local/bin/tx push -t -f -l <comma,sep,langs>` from the dhis2-core repo. This retires the bad translations in Transifex's database. **Round-trip verify** by re-pulling one or two languages and diffing.
+4. **(Optional) Add AI placeholders** — for major/widely-spoken languages, generate AI-translated placeholders to avoid English-in-UI while translators catch up. Mark them in-file with a `#-- AI-assisted, pending translator review --#` comment. Push the same way.
+5. **Commit and PR to core** — open PR against `master`. Deletions only — Transifex push is separate.
+6. **Backport** — re-run the deletion script on each supported branch (`2.43`, `2.42`, `2.41`, `2.40`). The script handles per-branch source differences automatically (skips keys not in that branch's source).
+
+## Watch out for
+
+- **`.tx/config` has a non-existent resource ID** (`r:i18n-global-properties` without branch prefix). The CLI tolerates it via branch heuristics, but the REST API returns 404 for that exact ID. Real resources are `r:master--i18n-global-properties`, `r:2-43--i18n-global-properties`, etc.
+- **One push covers all branches** — Transifex resources are version-tagged (`master--`, `2-43--` etc.) but the project is shared. After the master-branch push, the same translations are available for ALL branch sync runs.
+- **Stale bot PRs reintroduce fakes** — if a bot sync PR's head is older than your `tx push`, merging it brings the old (bad) translations back. Always check the bot PR's `updatedAt` vs your push date.
+
+## The bot-PR signing problem
+
+The `dhis2-bot` opens sync PRs but the commits are **unsigned + missing DCO Signed-off-by**. They sit at `MERGEABLE/BLOCKED`. Two approaches:
+
+- **Permanent fix:** PR https://github.com/dhis2/transifex-ci/pull/12 adds `--signoff` + SSH signing to `transyncosaurus_ALL.sh`. Once merged + admin sets the `DHIS2_BOT_SSH_SIGNING_KEY` secret, future bot PRs are mergeable.
+- **Per-PR workaround** (until the permanent fix lands):
+  ```bash
+  PR=23981; BASE=master; HEAD_BRANCH=master-transifex-ALL-<timestamp>
+  git fetch origin $BASE $HEAD_BRANCH
+  git worktree add /tmp/tx-amend origin/$HEAD_BRANCH
+  cd /tmp/tx-amend
+  git checkout -B local-amend-$PR
+  git rebase --signoff origin/$BASE     # adds Signed-off-by + GPG-signs if gpg-agent unlocked
+  git push --force-with-lease origin local-amend-$PR:$HEAD_BRANCH
+  cd - && git worktree remove /tmp/tx-amend --force
+  ```
+  Needs gpg-agent unlocked. Warm with `git commit --allow-empty -S -m "warm gpg-agent"` in your interactive shell.
+
+## tx CLI setup (one-time)
+
+```bash
+# Install
+curl -fsSL https://api.github.com/repos/transifex/cli/releases/latest | grep tx-linux-amd64.tar.gz | grep browser_download_url | cut -d'"' -f4 | xargs curl -fsSL -o /tmp/tx.tar.gz
+cd /tmp && tar -xzf tx.tar.gz && mv tx ~/.local/bin/tx && chmod +x ~/.local/bin/tx
+
+# Credentials — generate token at https://app.transifex.com/user/settings/api/
+# Then write ~/.transifexrc IN YOUR TERMINAL, never paste tokens in chat:
+umask 077 && cat > ~/.transifexrc <<EOF
+[https://www.transifex.com]
+rest_hostname = https://rest.api.transifex.com
+token = PASTE_TOKEN_HERE
+EOF
+chmod 600 ~/.transifexrc
+```
+
+## Common mistakes
+
+| Mistake | What goes wrong |
+|---|---|
+| Delete in repo, forget `tx push -t` | Next `tx pull` reintroduces the bad strings |
+| Blind `sed -i` to remove keys | Removes real translations too — always compare to source value first |
+| Push translations as English (looks like a translator did it) | Creates more fake translations — the original bug |
+| Merge a stale bot PR after your push | Reverts your work to the bot's older snapshot |
+| Auto-translate low-resource languages with AI | Quality is unreliable for `ckb`/`km`/`my`/`or`/`prs`/`ps`/`si`/`tet`/`tg` — skip them, let native speakers handle |
+| Commit to dhis2-core PR but skip Transifex push | Only fixes one branch's repo, not the source of truth |
+| Run `tx push -s` (source) to "fix" translations | Source push is the bot's job; doing it manually is redundant and risks pushing partially-staged source. **Only push `-t` (translations) for cleanup.** |
+| Use `--dry-run` on `tx push` | The modern tx CLI's `--dry-run` flag does not work reliably on `push`. Verify by re-pulling one language after push and diffing — that's the canonical sanity check. |
+| Try to "mark strings as unreviewed in Transifex UI" | There is no clean per-string "unreviewed" toggle. The actual retirement workflow is: delete from `.properties` file, `tx push -t -f`, post a Transifex Announcement asking translators to retranslate. |
+| Cherry-pick from an open (unmerged) backport PR's head SHA | Will conflict when those PRs eventually merge. Cherry-pick only from `master` commits that have actually landed. If a backport PR is already open, ADD to it instead. |
+| Notify translators via guessed Slack channels | Use the **Transifex Announcements** feature on the project (Settings → Announcements). It's the official channel — translators get notified in-app and via email. Phil owns the Transifex project; ping him if you don't have Maintainer rights. |
+| Declare ticket done at PR-merge time | The bot's next nightly sync will open a follow-up PR pulling translator updates. That PR **may be blocked by missing signatures** (see "bot-PR signing problem" above). Confirm the resync PR merges before closing the JIRA. |
+
+## Stakeholders
+
+- **Phil** — translation/Transifex owner. Ping him for: Maintainer-level Transifex tasks, posting announcements to translators, transifex-ci CI changes, bot account access.
+- **QA reporters** (e.g. Lina for Russian) — file the JIRA ticket and verify the fix.
+- **Repo write access on dhis2-core** — assumed; backport PRs push branches directly to origin.
+
+## Reference docs in dhis2-core repo
+
+When working in dhis2-core, look at:
+- `dhis-2/TRANSLATIONS_SECURITY_ANALYSIS.md` — example deep-dive for one cleanup (DHIS2-19912)
+- `dhis-2/TRANSLATIONS_ACTION_PLAN.md` — step-by-step playbook
+- `dhis-2/TRANSLATION_TODO.md` — current handoff state (if mid-flight)
+
+## Tools in this skill dir
+
+- `audit-fake-translations.py` — list fake translations per language, with key/regex filtering
+- `delete-fake-translations.py` — remove fakes from translation files (only deletes lines where value byte-equals English source)

--- a/skills/syncing-dhis2-translations/audit-fake-translations.py
+++ b/skills/syncing-dhis2-translations/audit-fake-translations.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Audit fake "English-as-translation" entries in DHIS2 i18n_global_*.properties files.
+
+A "fake translation" is a key whose target-language value is byte-identical to the
+English source value. Examples:
+    # i18n_global_ru.properties
+    verify_email_subject=Verify email address     # ← English, should be Cyrillic
+
+Run from the dhis2-core repo root (the directory containing dhis-2/).
+
+Usage:
+    # All fakes per language
+    python3 audit-fake-translations.py
+
+    # Filter by specific keys (comma-separated)
+    python3 audit-fake-translations.py --keys verify_email_subject,login_with_google
+
+    # Filter by regex on key name
+    python3 audit-fake-translations.py --regex 'email_(verify|2fa)|login_with'
+
+    # Only certain languages
+    python3 audit-fake-translations.py --langs ru,es,pt
+
+    # Limit output to N fake examples per language
+    python3 audit-fake-translations.py --limit 5
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+
+BASE_DIR = "dhis-2/dhis-services/dhis-service-core/src/main/resources"
+
+# Keys whose source value is a brand/common word that may match across languages —
+# the audit cannot tell whether these are fakes or legitimate.
+FALSE_POSITIVES = {"openid"}
+
+
+def parse_props(path):
+    """Parse a .properties file into a dict of key -> raw value (escapes preserved)."""
+    out = {}
+    if not os.path.exists(path):
+        return out
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or line.startswith("#") or line.startswith("!"):
+                continue
+            m = re.match(r"^([^=]+?)\s*=\s*(.*)$", line)
+            if m:
+                out[m.group(1).strip()] = m.group(2)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--keys", help="Comma-separated list of keys to check")
+    ap.add_argument("--regex", help="Regex on key name to filter (case-insensitive)")
+    ap.add_argument("--langs", help="Comma-separated language codes to check (default: all)")
+    ap.add_argument("--limit", type=int, default=0, help="Max fakes to print per language (0 = no limit)")
+    ap.add_argument("--base", default=BASE_DIR, help=f"Base path to i18n files (default: {BASE_DIR})")
+    args = ap.parse_args()
+
+    src_path = f"{args.base}/i18n_global.properties"
+    if not os.path.exists(src_path):
+        print(f"Source file not found: {src_path}", file=sys.stderr)
+        print("Run this from the dhis2-core repo root (the directory containing dhis-2/).", file=sys.stderr)
+        sys.exit(1)
+
+    src = parse_props(src_path)
+
+    key_filter = None
+    if args.keys:
+        wanted = set(k.strip() for k in args.keys.split(","))
+        key_filter = lambda k: k in wanted
+    elif args.regex:
+        rx = re.compile(args.regex, re.IGNORECASE)
+        key_filter = lambda k: bool(rx.search(k))
+
+    lang_filter = None
+    if args.langs:
+        wanted_langs = set(l.strip() for l in args.langs.split(","))
+        lang_filter = lambda l: l in wanted_langs
+
+    files = sorted(glob.glob(f"{args.base}/i18n_global_*.properties"))
+    total = 0
+    langs_affected = 0
+    print(f"{'Lang':<14} {'Fake':>5}  Examples")
+    print("-" * 60)
+    for path in files:
+        lang = os.path.basename(path)[len("i18n_global_"): -len(".properties")]
+        if lang_filter and not lang_filter(lang):
+            continue
+        tr = parse_props(path)
+        fakes = []
+        for k, v in tr.items():
+            if k in FALSE_POSITIVES:
+                continue
+            if k not in src:
+                continue
+            if src[k] != v:
+                continue
+            if not v.strip():
+                continue
+            if key_filter and not key_filter(k):
+                continue
+            fakes.append(k)
+        if fakes:
+            total += len(fakes)
+            langs_affected += 1
+            sample = fakes[: args.limit] if args.limit else fakes[:3]
+            extra = "" if (args.limit and len(fakes) <= args.limit) or len(fakes) <= 3 else " …"
+            print(f"{lang:<14} {len(fakes):>5}  {sample}{extra}")
+
+    print(f"\nTotal fake translations: {total}")
+    print(f"Languages affected: {langs_affected}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/syncing-dhis2-translations/delete-fake-translations.py
+++ b/skills/syncing-dhis2-translations/delete-fake-translations.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Delete fake "English-as-translation" entries from DHIS2 i18n_global_*.properties files.
+
+ONLY deletes lines where the target value is byte-identical to the English source.
+Real translations are preserved untouched.
+
+Run from the dhis2-core repo root (the directory containing dhis-2/).
+
+Usage:
+    # Delete specific keys (comma-separated)
+    python3 delete-fake-translations.py --keys verify_email_subject,login_with_google
+
+    # Delete keys matching a regex
+    python3 delete-fake-translations.py --regex 'email_(verify|2fa)|login_with'
+
+    # Dry-run: print what would be deleted, don't modify files
+    python3 delete-fake-translations.py --keys verify_email_subject --dry-run
+
+    # Restrict to certain languages
+    python3 delete-fake-translations.py --keys ... --langs ru,es,pt
+
+Workflow after running:
+    1. git diff to verify only fake lines were removed
+    2. git add + commit + push the deletion
+    3. Push the cleanup to Transifex too:
+         ~/.local/bin/tx push -t -f -l <affected,langs>
+       Otherwise the next `tx pull` reintroduces the bad strings.
+    4. Round-trip verify: tx pull one or two languages and diff against your committed state.
+"""
+import argparse
+import glob
+import os
+import re
+import sys
+
+BASE_DIR = "dhis-2/dhis-services/dhis-service-core/src/main/resources"
+
+
+def get_source_values(src_path, keys):
+    """Return {key: raw_value} from source file for the given keys."""
+    vals = {k: None for k in keys}
+    with open(src_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            for k in keys:
+                if vals[k] is None and line.startswith(f"{k}="):
+                    vals[k] = line[len(k) + 1:]
+                    break
+    return vals
+
+
+def list_source_keys_matching(src_path, regex):
+    rx = re.compile(regex, re.IGNORECASE)
+    out = []
+    with open(src_path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or line.startswith("#"):
+                continue
+            m = re.match(r"^([^=]+?)\s*=", line)
+            if m and rx.search(m.group(1).strip()):
+                out.append(m.group(1).strip())
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument("--keys", help="Comma-separated keys to delete")
+    group.add_argument("--regex", help="Regex on key name to match keys to delete (case-insensitive)")
+    ap.add_argument("--langs", help="Comma-separated language codes (default: all)")
+    ap.add_argument("--dry-run", action="store_true", help="Print what would be deleted without modifying files")
+    ap.add_argument("--base", default=BASE_DIR, help=f"Base path to i18n files (default: {BASE_DIR})")
+    args = ap.parse_args()
+
+    src_path = f"{args.base}/i18n_global.properties"
+    if not os.path.exists(src_path):
+        print(f"Source file not found: {src_path}", file=sys.stderr)
+        print("Run this from the dhis2-core repo root (the directory containing dhis-2/).", file=sys.stderr)
+        sys.exit(1)
+
+    if args.keys:
+        keys = [k.strip() for k in args.keys.split(",") if k.strip()]
+    else:
+        keys = list_source_keys_matching(src_path, args.regex)
+        print(f"Regex matched {len(keys)} key(s) in source: {keys}\n")
+        if not keys:
+            sys.exit(0)
+
+    src_vals = get_source_values(src_path, keys)
+    missing = [k for k, v in src_vals.items() if v is None]
+    if missing:
+        print(f"WARNING: keys NOT in this branch's source file (will be skipped): {missing}\n")
+
+    lang_filter = None
+    if args.langs:
+        wanted = set(l.strip() for l in args.langs.split(","))
+        lang_filter = lambda l: l in wanted
+
+    total_files = total_lines = 0
+    detail = {}
+
+    for path in sorted(glob.glob(f"{args.base}/i18n_global_*.properties")):
+        lang = os.path.basename(path)[len("i18n_global_"): -len(".properties")]
+        if lang_filter and not lang_filter(lang):
+            continue
+        with open(path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+        new_lines = []
+        deleted = []
+        for line in lines:
+            stripped = line.rstrip("\n")
+            kept = True
+            for k in keys:
+                if stripped.startswith(f"{k}="):
+                    raw_val = stripped[len(k) + 1:]
+                    # Only delete if target value byte-equals source
+                    if src_vals[k] is not None and raw_val == src_vals[k]:
+                        kept = False
+                        deleted.append(k)
+                    break
+            if kept:
+                new_lines.append(line)
+        if deleted:
+            if not args.dry_run:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.writelines(new_lines)
+            total_files += 1
+            total_lines += len(deleted)
+            detail[lang] = deleted
+
+    mode = "[DRY-RUN] " if args.dry_run else ""
+    print(f"{mode}Modified {total_files} files, deleted {total_lines} fake lines.\n")
+    for lang, dels in sorted(detail.items(), key=lambda x: (-len(x[1]), x[0])):
+        print(f"  {lang:<14} -{len(dels)}  {dels[:3]}{'…' if len(dels) > 3 else ''}")
+
+    if not args.dry_run and total_lines:
+        affected_langs = ",".join(sorted(detail.keys()))
+        print(f"\nNext steps:")
+        print(f"  1. git diff   # verify only fake lines were removed")
+        print(f"  2. git add + commit --signoff + push")
+        print(f"  3. Push to Transifex (CRITICAL — otherwise next tx pull reintroduces them):")
+        print(f"     ~/.local/bin/tx push -t -f -l {affected_langs}")
+        print(f"  4. Round-trip verify: tx pull -l ru -f --skip; git diff")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a Claude Code skill that captures the workflow for fixing fake "English-as-translation" entries in `i18n_global_*.properties` — the recurring bug where the English source text was saved as a "translation" in Russian, Spanish, etc., causing those users to see English in the UI.

The skill grew out of the [DHIS2-19912](https://dhis2.atlassian.net/browse/DHIS2-19912) cleanup. The same playbook applies to future regressions.

## What's in the skill

- **`SKILL.md`** — pipeline overview (Phil's 4-step process), the "fake translation" detection pattern, full cleanup workflow, tx CLI setup, the bot-PR signing situation and workaround, common mistakes table, stakeholders, links to deep-dive docs
- **`audit-fake-translations.py`** — list keys where the target value byte-equals the English source (per language), with `--keys` or `--regex` filtering
- **`delete-fake-translations.py`** — safely remove fakes (never deletes real translations because it compares value-for-value to source); has `--dry-run`

## Why a top-level `skills/` directory

Claude Code skills are a specific [format](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) (YAML-frontmatter `SKILL.md` plus supporting scripts) distinct from regular markdown guides. A dedicated directory:

- keeps the format separable from `/guides/`
- gives a clear home for future team skills (Flyway conflict resolution, OSIV migration prep, etc.)
- lets devs symlink one specific skill into `~/.claude/skills/` without bringing along the whole `/guides/` tree

`skills/README.md` documents installation (symlink vs. copy) and contribution conventions (naming, descriptions).

## How to use after merge

```bash
# Adjust path to your wow-backend clone
ln -s ~/src/dhis2/wow-backend/skills/syncing-dhis2-translations \
      ~/.claude/skills/syncing-dhis2-translations
```

Next Claude Code session will pick it up automatically. Ask Claude something like *"investigate fake Russian translations in dhis2-core"* and it'll invoke the skill.

## Tested

The skill was iteratively RED/GREEN-tested with subagent baseline scenarios:
- RED (without skill): agent suggested `tx push -s`, `--dry-run` push, "mark unreviewed in Transifex UI", guessed Slack channel for translator notification, missed the bot-signing gotcha
- GREEN (with skill): all the above fixed; agent followed the canonical delete-and-`tx push -t -f` workflow, knew to use the Transifex Announcements feature, and flagged the bot resync PR may need amending

## Test plan
- [ ] Reviewer reads `skills/syncing-dhis2-translations/SKILL.md` and confirms it matches their mental model of the workflow
- [ ] Reviewer tries the symlink installation and confirms Claude Code lists the skill
- [ ] (Optional) Verify by running `audit-fake-translations.py` on a current branch

AI Assisted

[DHIS2-19912]: https://dhis2.atlassian.net/browse/DHIS2-19912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ